### PR TITLE
Add banner image and tagline to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Y—Tags
+![Y—Tags](https://user-images.githubusercontent.com/1037520/220168883-0452b4bb-bd1c-41cd-b29f-207eb93fa25b.jpeg)
+_Accessible and customizable tag user interface elements for iOS._
 
 Licensing
 ----------


### PR DESCRIPTION
## Introduction ##

All of our public repo's have banner images in the same style. Y—Tags needs one too.

## Purpose ##

Add a banner image to the README

## Scope ##

Update README

## Discussion ##

I also added a tagline for the repo. This will be it's short description.

## Screenshots 📱 ##

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/1037520/220293812-4e305322-86c5-453f-85ba-f5aff2315530.png">
