### PR TITLE
[CM-1220] Tag view component alignment changed to centre.

### DIFF
--- a/Sources/YTags/TagView.swift
+++ b/Sources/YTags/TagView.swift
@@ -32,7 +32,7 @@ open class TagView: UIView {
     private let stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.alignment = .leading
+        stackView.alignment = .center
         stackView.distribution = .fill
         return stackView
     }()


### PR DESCRIPTION
## Introduction ##

Tag view component alignment changed to centre

## Purpose ##

To align all the tag element to centre.

## Scope ##

`HStack` alignment changed to center.


## 📱 Screenshots ##
<img width="352" alt="Screenshot 2023-03-09 at 10 17 19 AM" src="https://user-images.githubusercontent.com/102538361/223920391-e3994677-8253-4609-b815-b25594066bc9.png">

<img width="244" alt="Screenshot 2023-03-09 at 10 17 10 AM" src="https://user-images.githubusercontent.com/102538361/223920438-ec7a1c83-c779-4484-96db-6e263e75cf5c.png">


## 📈 Coverage ##

##### Code #####
<img width="1204" alt="Screenshot 2023-03-09 at 10 18 18 AM" src="https://user-images.githubusercontent.com/102538361/223919984-f52ef3cd-535a-4df3-a48c-40eff62a2d41.png">


##### Documentation #####
<img width="776" alt="Screenshot 2023-03-09 at 10 19 07 AM" src="https://user-images.githubusercontent.com/102538361/223920065-12e94fa3-7129-4d41-ad11-624c974dde94.png">

