### PR TITLE
[CM-1223] Define accessibility elements

### DIFF
--- a/Sources/YTags/TagView.swift
+++ b/Sources/YTags/TagView.swift
@@ -141,6 +141,7 @@ private extension TagView {
         updateCloseButton()
         updateShape()
         updateHeights()
+        updateAccessibilityElements()
     }
     
     func updateIcon() {
@@ -171,6 +172,16 @@ private extension TagView {
         case .roundRect(let radius):
             layer.cornerRadius = radius
         }
+    }
+
+    func updateAccessibilityElements() {
+        var accessibilityElements: [Any]? = [titleLabel]
+
+        if appearance.hasCloseButton {
+            accessibilityElements?.append(closeButton)
+        }
+
+        self.accessibilityElements = accessibilityElements
     }
     
     @objc func tagDidClose() {

--- a/Tests/YTagsTests/TagViewTests.swift
+++ b/Tests/YTagsTests/TagViewTests.swift
@@ -161,6 +161,18 @@ final class TagViewTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.layer.borderWidth, oldBorderWidth + 1)
     }
+
+    func test_accessibilityElements() {
+        // Given
+        let sut = makeSUT()
+        XCTAssertEqual(sut.accessibilityElements?.count, 1)
+
+        // When
+        sut.appearance = TagView.Appearance(closeButton: .default)
+
+        // Then
+        XCTAssertEqual(sut.accessibilityElements?.count, 2)
+    }
 }
 
 private extension TagViewTests {


### PR DESCRIPTION
## Introduction ##

We want our tags to have the proper accessibility elements. For example, we don't want the optional icon to have an element as that is just decorative rather than informational. We do however want the close button to appear as an element, if it is visible.

## Purpose ##

Define the proper accessibility elements of the tag view.

## Scope ##

* Update `TagView`
* add unit tests

## 📈 Coverage ##

##### Code #####

100%

<img width="548" alt="image" src="https://user-images.githubusercontent.com/1037520/224319577-0b60774c-611d-41df-9313-6086938e3ffa.png">

##### Documentation #####

100%

<img width="553" alt="image" src="https://user-images.githubusercontent.com/1037520/224319745-b9fc52af-ccb4-48a3-bb49-11dc07777401.png">
