### PR TITLE
[CM-1237] Tag border colour issue fixed.

### DIFF
--- a/Sources/YTags/TagView.swift
+++ b/Sources/YTags/TagView.swift
@@ -86,6 +86,8 @@ open class TagView: UIView {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentFontAppearance(comparedTo: previousTraitCollection) {
             updateViewAppearance()
+        } else if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            updateBorderColor()
         }
     }
 
@@ -132,16 +134,20 @@ private extension TagView {
     
     func updateViewAppearance() {
         backgroundColor = appearance.backgroundColor
-        layer.borderColor = appearance.borderColor.cgColor
         layer.borderWidth = appearance.borderWidth(compatibleWith: traitCollection)
         titleLabel.textColor = appearance.title.textColor
         titleLabel.typography = appearance.title.typography
         stackView.spacing = appearance.layout.gap
+        updateBorderColor()
         updateIcon()
         updateCloseButton()
         updateShape()
         updateHeights()
         updateAccessibilityElements()
+    }
+    
+    func updateBorderColor() {
+        layer.borderColor = appearance.borderColor.cgColor
     }
     
     func updateIcon() {

--- a/Sources/YTags/TagView.swift
+++ b/Sources/YTags/TagView.swift
@@ -86,7 +86,8 @@ open class TagView: UIView {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentFontAppearance(comparedTo: previousTraitCollection) {
             updateViewAppearance()
-        } else if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+        }
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
             updateBorderColor()
         }
     }

--- a/Tests/YTagsTests/TagViewTests.swift
+++ b/Tests/YTagsTests/TagViewTests.swift
@@ -165,16 +165,27 @@ final class TagViewTests: XCTestCase {
     func test_updatedColorMode_changesBorderColor() {
         // Given
         let sut = makeSUT()
-        let borderColor = sut.layer.borderColor
+        let darkBorderColor  = UIColor.white
+        let lightBorderColor = UIColor.black
         let (parent, child) = makeNestedViewControllers(subview: sut)
         
         // When
-        let traits = UITraitCollection(userInterfaceStyle: .dark)
-        parent.setOverrideTraitCollection(traits, forChild: child)
-        sut.traitCollectionDidChange(traits)
+        let traitDark = UITraitCollection(userInterfaceStyle: .dark)
+        parent.setOverrideTraitCollection(traitDark, forChild: child)
+        sut.traitCollectionDidChange(traitDark)
+        sut.appearance.borderColor = darkBorderColor
         
         // Then
-        XCTAssertEqual(sut.layer.borderColor, borderColor)
+        XCTAssertEqual(sut.layer.borderColor, darkBorderColor.cgColor)
+        
+        // When
+        let traitLight = UITraitCollection(userInterfaceStyle: .light)
+        parent.setOverrideTraitCollection(traitLight, forChild: child)
+        sut.traitCollectionDidChange(traitLight)
+        sut.appearance.borderColor = lightBorderColor
+        
+        // Then
+        XCTAssertEqual(sut.layer.borderColor, lightBorderColor.cgColor)
     }
 
     func test_accessibilityElements() {

--- a/Tests/YTagsTests/TagViewTests.swift
+++ b/Tests/YTagsTests/TagViewTests.swift
@@ -162,7 +162,7 @@ final class TagViewTests: XCTestCase {
         XCTAssertEqual(sut.layer.borderWidth, oldBorderWidth + 1)
     }
     
-    func test_changeColorMode() {
+    func test_updatedColorMode_changesBorderColor() {
         // Given
         let sut = makeSUT()
         let borderColor = sut.layer.borderColor

--- a/Tests/YTagsTests/TagViewTests.swift
+++ b/Tests/YTagsTests/TagViewTests.swift
@@ -161,6 +161,21 @@ final class TagViewTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.layer.borderWidth, oldBorderWidth + 1)
     }
+    
+    func test_changeColorMode() {
+        // Given
+        let sut = makeSUT()
+        let borderColor = sut.layer.borderColor
+        let (parent, child) = makeNestedViewControllers(subview: sut)
+        
+        // When
+        let traits = UITraitCollection(userInterfaceStyle: .dark)
+        parent.setOverrideTraitCollection(traits, forChild: child)
+        sut.traitCollectionDidChange(traits)
+        
+        // Then
+        XCTAssertEqual(sut.layer.borderColor, borderColor)
+    }
 
     func test_accessibilityElements() {
         // Given


### PR DESCRIPTION
## Introduction ##

Tag border does not update when colour mode changes.

## Purpose ##

Tag border does not update when colour mode changes.

## Scope ##

Border colour updated once the appearance changed.


## 📱 Screenshots ##

<img width="263" alt="tag dark" src="https://user-images.githubusercontent.com/102538361/225226062-4e91bfa0-ace6-4cef-83e2-6f4b40543631.png">

<img width="251" alt="tag light" src="https://user-images.githubusercontent.com/102538361/225226073-f5676831-b2c5-4889-add3-aa496312e799.png">

## 📈 Coverage ##

##### Code #####

<img width="1205" alt="Screenshot 2023-03-15 at 12 05 55 PM" src="https://user-images.githubusercontent.com/102538361/225226212-07fe17b4-f12c-4586-916d-155055e07eb9.png">


##### Documentation #####
<img width="746" alt="Screenshot 2023-03-15 at 12 06 59 PM" src="https://user-images.githubusercontent.com/102538361/225226496-19795767-06f4-40b3-a68a-021e16039adc.png">

