### PR TITLE
[Issue-14] Support for scaled round rect.

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/YTags.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/YTags.xcscheme
@@ -44,7 +44,8 @@
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "YTagsTests"

--- a/Package.swift
+++ b/Package.swift
@@ -18,11 +18,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/yml-org/YCoreUI.git",
-            from: "1.4.0"
+            from: "1.6.0"
         ),
         .package(
             url: "https://github.com/yml-org/YMatterType.git",
-            from: "1.4.0"
+            from: "1.6.0"
         )
     ],
     targets: [

--- a/Sources/YTags/TagView+Shape.swift
+++ b/Sources/YTags/TagView+Shape.swift
@@ -17,5 +17,7 @@ extension TagView.Appearance {
         case roundRect(cornerRadius: CGFloat)
         /// Capsule.
         case capsule
+        /// Scaled round rect.
+        case scaledRoundRect(cornerRadius: CGFloat)
     }
 }

--- a/Sources/YTags/TagView+Shape.swift
+++ b/Sources/YTags/TagView+Shape.swift
@@ -9,15 +9,15 @@
 import UIKit
 
 extension TagView.Appearance {
-    /// Tag shape.
+    /// Tag shape
     public enum Shape: Equatable {
-        /// Rectangle.
+        /// Rectangle
         case rectangle
-        /// Rounded rectangle.
+        /// Rounded rectangle
         case roundRect(cornerRadius: CGFloat)
-        /// Capsule.
-        case capsule
-        /// Scaled round rect.
+        /// Scaled round rect
         case scaledRoundRect(cornerRadius: CGFloat)
+        /// Capsule
+        case capsule
     }
 }

--- a/Sources/YTags/TagView.Appearance+Layout.swift
+++ b/Sources/YTags/TagView.Appearance+Layout.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import YCoreUI
 
 extension TagView.Appearance {
     /// A collection of layout properties for the `TagView`.

--- a/Sources/YTags/TagView.swift
+++ b/Sources/YTags/TagView.swift
@@ -178,6 +178,9 @@ private extension TagView {
             layer.cornerRadius = 0
         case .roundRect(let radius):
             layer.cornerRadius = radius
+        case .scaledRoundRect(let radius):
+            let scaledFactor = titleLabel.layout.lineHeight / titleLabel.typography.lineHeight
+            layer.cornerRadius = radius * scaledFactor
         }
     }
 

--- a/Tests/YTagsTests/TagViewTests.swift
+++ b/Tests/YTagsTests/TagViewTests.swift
@@ -139,6 +139,19 @@ final class TagViewTests: XCTestCase {
         XCTAssertEqual(sut.appearance.shape, .roundRect(cornerRadius: cornerRadius))
     }
     
+    func test_customScaledShape() {
+        let sut = makeSUT()
+        let cornerRadius: CGFloat = 13
+        sut.appearance.shape = .scaledRoundRect(cornerRadius: cornerRadius)
+        
+        sut.layoutIfNeeded()
+        
+        let scaledFactor = sut.titleLabel.layout.lineHeight / sut.titleLabel.typography.lineHeight
+        
+        XCTAssertEqual(sut.layer.cornerRadius, cornerRadius * scaledFactor )
+        XCTAssertEqual(sut.appearance.shape, .scaledRoundRect(cornerRadius: cornerRadius))
+    }
+    
     func test_defaultShape() {
         let sut = makeSUT()
         sut.layoutIfNeeded()

--- a/Tests/YTagsTests/TagViewTests.swift
+++ b/Tests/YTagsTests/TagViewTests.swift
@@ -130,7 +130,7 @@ final class TagViewTests: XCTestCase {
     
     func test_customShape() {
         let sut = makeSUT()
-        let cornerRadius: CGFloat = 13
+        let cornerRadius = CGFloat(Int.random(in: 1...13))
         sut.appearance.shape = .roundRect(cornerRadius: cornerRadius)
         
         sut.layoutIfNeeded()
@@ -139,16 +139,21 @@ final class TagViewTests: XCTestCase {
         XCTAssertEqual(sut.appearance.shape, .roundRect(cornerRadius: cornerRadius))
     }
     
-    func test_customScaledShape() {
+    func test_scaledRoundRectShape() {
+        // Given
         let sut = makeSUT()
-        let cornerRadius: CGFloat = 13
+        sut.titleLabel.maximumScaleFactor = 2
+        let cornerRadius = CGFloat(Int.random(in: 1...8))
         sut.appearance.shape = .scaledRoundRect(cornerRadius: cornerRadius)
-        
-        sut.layoutIfNeeded()
-        
-        let scaledFactor = sut.titleLabel.layout.lineHeight / sut.titleLabel.typography.lineHeight
-        
-        XCTAssertEqual(sut.layer.cornerRadius, cornerRadius * scaledFactor )
+        let (parent, child) = makeNestedViewControllers(subview: sut)
+
+        // When
+        let traits = UITraitCollection(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge)
+        parent.setOverrideTraitCollection(traits, forChild: child)
+        sut.traitCollectionDidChange(traits)
+
+        // Then
+        XCTAssertEqual(sut.layer.cornerRadius, 2 * cornerRadius)
         XCTAssertEqual(sut.appearance.shape, .scaledRoundRect(cornerRadius: cornerRadius))
     }
     


### PR DESCRIPTION
## Introduction ##

Support added for the scaled round rect shape.

## Purpose ##

- Corner radius of tag should be scaled relative to the dynamic text. 
- Fix #14 

## Scope ##

A new shaped has been introduced `scaledRoundRect(cornerRadius: CGFloat)` in the `Shape` enum.

## 🎬 Video ##

![scaled](https://user-images.githubusercontent.com/102538361/229727342-14578760-4668-4e30-a85d-2ab1e3aaa755.gif)



## 📈 Coverage ##

##### Code #####

<img width="1295" alt="Screenshot 2023-04-04 at 1 24 56 PM" src="https://user-images.githubusercontent.com/102538361/229726632-a16f7a38-036c-453a-80b4-fa1b6b832a3d.png">


##### Documentation #####

<img width="784" alt="Screenshot 2023-04-04 at 1 14 27 PM" src="https://user-images.githubusercontent.com/102538361/229723471-44cc10b1-f3b9-45bc-9059-49899d2f1772.png">
